### PR TITLE
Trim trailing slashes from inbound URIs

### DIFF
--- a/Manager/RedirectManager.php
+++ b/Manager/RedirectManager.php
@@ -97,7 +97,7 @@ class RedirectManager
         $requestUri = $request->getRequestUri();
 
         $source = mb_eregi_replace($baseUrl, '', $requestUri);
-        $source = ltrim($source, '/');
+        $source = trim($source, '/');
 
         $redirect = $this->getRepository()
                         ->getDestinationFromSource($source);


### PR DESCRIPTION
Rather than having to duplicate data in the url map, I'm proposing that the trailing slash (if present) is dropped from the source, we are having alot of 404s generated because of this issue.

I know that /my-url and /my-url/ should be considered different, but pragmatically its often the case that they are treated as being synonymous.

This will break BC if the URLs in the database have trailing slashes
